### PR TITLE
Fix code scanning alert no. 19: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/Season-1/Level-5/solution.py
+++ b/Season-1/Level-5/solution.py
@@ -20,17 +20,15 @@ class Random_generator:
 
 class SHA256_hasher:
 
-    # produces the password hash by combining password + salt because hashing
+    # produces the password hash using bcrypt
     def password_hash(self, password, salt):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = bcrypt.hashpw(password, salt)
+        password_hash = bcrypt.hashpw(password.encode(), salt)
         return password_hash.decode('ascii')
 
-    # verifies that the hashed password reverses to the plain text version on verification
+    # verifies that the hashed password matches the plain text version on verification
     def password_verification(self, password, password_hash):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
         password_hash = password_hash.encode('ascii')
-        return bcrypt.checkpw(password, password_hash)
+        return bcrypt.checkpw(password.encode(), password_hash)
 
 # a collection of sensitive secrets necessary for the software to operate
 PRIVATE_KEY = os.environ.get('PRIVATE_KEY')


### PR DESCRIPTION
Fixes [https://github.com/672641/skills-secure-code-game/security/code-scanning/19](https://github.com/672641/skills-secure-code-game/security/code-scanning/19)

To fix the problem, we should replace the use of SHA-256 with a more secure password hashing algorithm directly. We can use bcrypt for both hashing and verifying passwords, which is already imported and used in the code. This will ensure that the password hashing is computationally expensive and secure.

- Remove the SHA-256 hashing step and directly use bcrypt to hash the password with the salt.
- Update the `password_hash` and `password_verification` methods to use bcrypt directly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
